### PR TITLE
Custom Redux Middleware

### DIFF
--- a/src/lib/createStore.js
+++ b/src/lib/createStore.js
@@ -12,10 +12,10 @@ function _gluestick(state=true, action) {
   return state;
 }
 
-export default function (customRequire, hotCallback, devMode) {
+export default function (customRequire, customMiddleware, hotCallback, devMode) {
   const reducer = combineReducers(Object.assign({}, {_gluestick}, customRequire()));
   const composeArgs = [
-    applyMiddleware(promiseMiddleware, thunk)
+    applyMiddleware.apply(this, [promiseMiddleware, thunk, ...customMiddleware])
   ];
 
   // Include dev tools only if we are in development mode
@@ -35,4 +35,3 @@ export default function (customRequire, hotCallback, devMode) {
 
   return store;
 }
-


### PR DESCRIPTION
createStore takes in a customMiddleware param which is added after the promiseMiddleware and thunk. Some middleware, like redux-logger, has to be the last middleware added thus customMiddleware is added after.

This is a precursor to: https://github.com/TrueCar/gluestick/pull/40