### PR TITLE
Move httpClient logic into shared code

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "redux-thunk": "2.0.1"
   },
   "peerDependencies": {
+    "axios": ">=0.11.0",
     "radium": ">=0.16.6",
     "react-router": ">=2.0.0",
     "react-redux": ">=4.0.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 0",
+    "test": "mocha --compilers js:babel-core/register --require babel-polyfill --recursive",
     "clean": "rimraf build",
     "build": "webpack ./src/index.js",
     "prepublish": "npm run clean && npm run build"
@@ -39,10 +39,14 @@
   },
   "devDependencies": {
     "babel-loader": "6.2.4",
+    "babel-polyfill": "^6.8.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
     "babel-preset-stage-0": "6.5.0",
+    "chai": "^3.5.0",
+    "mocha": "^2.4.5",
     "rimraf": "^2.5.0",
+    "sinon": "^1.17.4",
     "webpack": "1.12.14"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react-dom": ">=0.14.3"
   },
   "devDependencies": {
+    "axios": "^0.11.0",
     "babel-loader": "6.2.4",
     "babel-polyfill": "^6.8.0",
     "babel-preset-es2015": "6.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick-shared",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ export createStore from "./lib/createStore";
 export prepareRoutesWithTransitionHooks from "./lib/prepareRoutesWithTransitionHooks";
 export * from "./lib/route-helper";
 export * from "./lib/constants";
+export getHttpClient from "./lib/getHttpClient";
 

--- a/src/lib/getHttpClient.js
+++ b/src/lib/getHttpClient.js
@@ -1,0 +1,26 @@
+import axios from "axios";
+
+/**
+ * @param {Object} options axios configuration options
+ * @param {Express.Request} [request] optional request object. If provided,
+ * headers will be merged
+ * https://github.com/mzabriskie/axios#request-config
+ * @param {axios} [axios] optionally override axios (used for tests/mocking)
+ */
+export default function getHttpClient (options, req, axios) {
+  if (!req) {
+    return axios.create(options);
+  }
+
+  const { headers, ...httpConfig } = options;
+
+  // If a request object is provided, 
+  return axios.create({
+    headers: {
+      ...req.headers,
+      ...headers
+    },
+    ...httpConfig
+  });
+}
+

--- a/src/lib/getHttpClient.js
+++ b/src/lib/getHttpClient.js
@@ -14,7 +14,8 @@ export default function getHttpClient (options={}, req, httpClient=axios) {
 
   const { headers, ...httpConfig } = options;
 
-  // If a request object is provided, 
+  // If a request object is provided, then we want to merge the custom headers
+  // with the headers that we sent from the browser in the request.
   return httpClient.create({
     headers: {
       ...req.headers,

--- a/src/lib/getHttpClient.js
+++ b/src/lib/getHttpClient.js
@@ -5,17 +5,17 @@ import axios from "axios";
  * @param {Express.Request} [request] optional request object. If provided,
  * headers will be merged
  * https://github.com/mzabriskie/axios#request-config
- * @param {axios} [axios] optionally override axios (used for tests/mocking)
+ * @param {axios} [httpClient] optionally override axios (used for tests/mocking)
  */
-export default function getHttpClient (options, req, axios) {
+export default function getHttpClient (options={}, req, httpClient=axios) {
   if (!req) {
-    return axios.create(options);
+    return httpClient.create(options);
   }
 
   const { headers, ...httpConfig } = options;
 
   // If a request object is provided, 
-  return axios.create({
+  return httpClient.create({
     headers: {
       ...req.headers,
       ...headers

--- a/test/lib/getHttpClient.test.js
+++ b/test/lib/getHttpClient.test.js
@@ -1,0 +1,50 @@
+import getHttpClient from "../../src/lib/getHttpClient";
+import sinon from "sinon";
+import { expect } from "chai";
+
+describe("lib/getHttpClient", () => {
+  it("should call create with passed params", () => {
+    const options = {
+      headers: {
+        "X-Todd": "Hi",
+        "test": "best"
+      },
+      rewriteRequest: [() => {}]
+    };
+    const mockAxios = {
+      create: sinon.spy()
+    };
+    const client = getHttpClient(options, undefined, mockAxios);
+    expect(mockAxios.create.calledWith(options)).to.equal(true);
+  });
+
+  it("should merge request headers if request object is passed", () => {
+    const options = {
+      headers: {
+        "X-Todd": "Hi",
+        "test": "best"
+      },
+      test2: "hi"
+    };
+    const req = {
+      headers: {
+        "cookie": "name=Lincoln"
+      }
+    };
+    const mockAxios = {
+      create: sinon.spy()
+    };
+    const client = getHttpClient(options, req, mockAxios);
+    expect(mockAxios.create.calledWith(options)).to.equal(false);
+
+    const { headers, ...config } = options;
+    expect(mockAxios.create.lastCall.args[0]).to.deep.equal({
+      headers: {
+        ...req.headers,
+        ...headers
+      },
+      ...config
+    });
+  });
+});
+

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,16 +41,22 @@ module.exports = {
 
   externals: [
     {
+      axios: {
+        root: "axios",
+        commonjs2: "axios",
+        commonjs: "axios",
+        amd: "axios"
+      },
       react: {
         root: "React",
         commonjs2: "react",
-        comonjs: "react",
+        commonjs: "react",
         amd: "react"
       },
       radium: {
         root: "Radium",
         commonjs2: "radium",
-        comonjs: "radium",
+        commonjs: "radium",
         amd: "radium"
       },
       "react-dom": {


### PR DESCRIPTION
### relied on by https://github.com/TrueCar/gluestick/pull/161

This is used in both the client and the server.

I also copied over the test command from `gluestick` and added tests for this new method.