### PR TITLE
Add a way to update body tag attributes (e-mail support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick-shared",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,15 +23,16 @@
   },
   "homepage": "https://github.com/TrueCar/gluestick-shared#readme",
   "dependencies": {
-    "redux-immutable-state-invariant": "1.2.2",
-    "redux-thunk": "2.0.1",
     "axios": ">=0.11.0",
     "radium": ">=0.16.6",
-    "react-router": ">=2.0.0",
-    "react-redux": ">=4.0.1",
-    "redux": ">=3.3.1",
     "react": ">=0.14.3",
-    "react-dom": ">=0.14.3"
+    "react-dom": ">=0.14.3",
+    "react-redux": ">=4.0.1",
+    "react-router": ">=2.0.0",
+    "react-side-effect": "1.0.2",
+    "redux": ">=3.3.1",
+    "redux-immutable-state-invariant": "1.2.2",
+    "redux-thunk": "2.0.1"
   },
   "devDependencies": {
     "babel-cli": "^6.8.0",

--- a/src/components/BodyAttributes.js
+++ b/src/components/BodyAttributes.js
@@ -34,9 +34,14 @@ function handleStateChangeOnClient(attrs) {
 function transformHTML4Props(props) {
   const transformedProps = {};
 
-  // Provide support for HTML4 attributes on the body tag for
-  // e-mail purposes. Convert tags to ones oy-vey can translate
-  // during the render.
+  /*
+   * Provide support for HTML4 attributes on the body tag for
+   * e-mail purposes. Convert tags to ones oy-vey can translate
+   * during the render.
+   *
+   * Note: Only attributes that are white-listed by oy-vey will be rendered
+   *
+   */
   Object.keys(supportedHTML4Attributes).forEach(propName => {
     if (props.hasOwnProperty(propName)) {
       const name = supportedHTML4Attributes[propName];

--- a/src/components/BodyAttributes.js
+++ b/src/components/BodyAttributes.js
@@ -13,8 +13,12 @@ BodyAttributes.propTypes = {
 
 function reducePropsToState(propsList) {
   const attrs = {};
+  const transformedAttrs = {};
   propsList.forEach(function (props) {
-    Object.assign(attrs, props);
+    if (props.hasOwnProperty("bgColor")) {
+      Object.assign(transformedAttrs, {"data-oy-bgcolor": props["bgColor"]});
+    }
+    Object.assign(attrs, props, transformedAttrs);
   });
   return attrs;
 }

--- a/src/components/BodyAttributes.js
+++ b/src/components/BodyAttributes.js
@@ -1,6 +1,11 @@
 import { Component, Children, PropTypes } from "react";
 import withSideEffect from "react-side-effect";
 
+
+const supportedHTML4Attributes = {
+  "bgColor": "bgcolor"
+};
+
 class BodyAttributes extends Component {
   render() {
     return Children.only(this.props.children);
@@ -13,11 +18,8 @@ BodyAttributes.propTypes = {
 
 function reducePropsToState(propsList) {
   const attrs = {};
-  const transformedAttrs = {};
   propsList.forEach(function (props) {
-    if (props.hasOwnProperty("bgColor")) {
-      Object.assign(transformedAttrs, {"data-oy-bgcolor": props["bgColor"]});
-    }
+    const transformedAttrs = transformHTML4Props(props);
     Object.assign(attrs, props, transformedAttrs);
   });
   return attrs;
@@ -27,6 +29,23 @@ function handleStateChangeOnClient(attrs) {
   for (const key in attrs) {
     document.body.setAttribute(key, attrs[key]);
   }
+}
+
+function transformHTML4Props(props) {
+  const transformedProps = {};
+
+  // Provide support for HTML4 attributes on the body tag for
+  // e-mail purposes. Convert tags to ones oy-vey can translate
+  // during the render.
+  Object.keys(supportedHTML4Attributes).forEach(propName => {
+    if (props.hasOwnProperty(propName)) {
+      const name = supportedHTML4Attributes[propName];
+      const value = props[propName];
+      const transformedProp = { [`data-oy-${name}`]: value };
+      Object.assign(transformedProps, transformedProp);
+    }
+  });
+  return transformedProps;
 }
 
 export default withSideEffect(

--- a/src/components/BodyAttributes.js
+++ b/src/components/BodyAttributes.js
@@ -1,0 +1,31 @@
+import { Component, Children, PropTypes } from "react";
+import withSideEffect from "react-side-effect";
+
+class BodyAttributes extends Component {
+  render() {
+    return Children.only(this.props.children);
+  }
+}
+
+BodyAttributes.propTypes = {
+  children: PropTypes.node.isRequired
+};
+
+function reducePropsToState(propsList) {
+  const attrs = {};
+  propsList.forEach(function (props) {
+    Object.assign(attrs, props);
+  });
+  return attrs;
+}
+
+function handleStateChangeOnClient(attrs) {
+  for (const key in attrs) {
+    document.body.setAttribute(key, attrs[key]);
+  }
+}
+
+export default withSideEffect(
+  reducePropsToState,
+  handleStateChangeOnClient
+)(BodyAttributes);

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from "react";
-import { Router, Route, browserHistory } from "react-router"
+import { Router, browserHistory } from "react-router";
 import { Provider } from "react-redux";
 
 import prepareRoutesWithTransitionHooks from "../lib/prepareRoutesWithTransitionHooks";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export Root from "./containers/Root";
+export BodyAttributes from "./components/BodyAttributes";
 export createStore from "./lib/createStore";
 export prepareRoutesWithTransitionHooks from "./lib/prepareRoutesWithTransitionHooks";
 export * from "./lib/route-helper";

--- a/src/lib/route-helper.js
+++ b/src/lib/route-helper.js
@@ -1,4 +1,4 @@
-import { match } from 'react-router';
+import { match } from "react-router";
 
 const getBeforeRoute = (component = {}) => {
   const c = component.WrappedComponent || component;
@@ -16,10 +16,12 @@ function getRouteComponents(routes) {
   const components = [];
 
   routes.forEach(route => {
-    if (route.components)
+    if (route.components) {
       Object.values(route.components).forEach(c => components.push(c));
-    else if (route.component)
+    }
+    else if (route.component) {
       components.push(route.component);
+    }
   });
 
   return components;
@@ -42,14 +44,14 @@ export function runBeforeRoutes (store, renderProps, serverProps) {
   .map(getBeforeRoute).filter(f => f) // only look at ones with a static gsBeforeRoute()
   .map(beforeRoute => beforeRoute(store, params, query || {}, serverProps));  // call fetch data methods and save promises
 
-  return Promise.all(promises)
+  return Promise.all(promises);
 }
 
 export function createTransitionHook (store, routes) {
   return function(location, cb) {
     match({routes: routes, location}, async function (error, redirectLocation, renderProps) {
       try {
-        await runBeforeRoutes(store, renderProps)
+        await runBeforeRoutes(store, renderProps);
       } catch(err) {
         console.error(err);
       } finally {


### PR DESCRIPTION
Use [react-side-effect](https://github.com/gaearon/react-side-effect) to create a component that will allow child components to update body tag attributes. This will allow e-mail components to update attributes for server-side rendering.