### PR TITLE
add react-router-scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick-shared",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "react-dom": ">=0.14.3",
     "react-redux": ">=4.0.1",
     "react-router": ">=2.0.0",
+    "react-router-scroll": ">=0.2.0",
     "react-side-effect": "1.0.2",
     "redux": ">=3.3.1",
     "redux-immutable-state-invariant": "1.2.2",

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from "react";
-import { Router, browserHistory } from "react-router";
+import { applyRouterMiddleware, Router, browserHistory } from "react-router";
 import { Provider } from "react-redux";
+import useScroll from "react-router-scroll";
 
 import prepareRoutesWithTransitionHooks from "../lib/prepareRoutesWithTransitionHooks";
 
@@ -52,7 +53,7 @@ export default class Root extends Component {
     if (routerContext) return routerContext;
 
     return (
-      <Router history={routerHistory}>
+      <Router history={routerHistory} render={applyRouterMiddleware(useScroll())}>
         {prepareRoutesWithTransitionHooks(routes)}
       </Router>
     );


### PR DESCRIPTION
The default behavior when routing between pages should be that the user
is taken to the top of the page. I'm not sure why this isn't the default
behavior of react-router but this middleware makes it behaive correctly.