### PR TITLE
Improve existing action names and add new actions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,5 @@ export prepareRoutesWithTransitionHooks from "./lib/prepareRoutesWithTransitionH
 export * from "./lib/route-helper";
 export * from "./lib/constants";
 export getHttpClient from "./lib/getHttpClient";
-export { render404, renderStatus } from "./lib/actions";
+export { set404StatusCode, setStatusCode } from "./lib/actions";
 

--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -1,13 +1,13 @@
-export const RENDER_STATUS = "RENDER_STATUS";
+export const SET_STATUS_CODE = "SET_STATUS_CODE";
 
-export function render404 (message) {
-  return renderStatus (404, message);
+
+export function set404StatusCode() {
+  return setStatusCode(404);
 }
 
-export function renderStatus (statusCode, message) {
+export function setStatusCode(statusCode) {
   return {
-    type: RENDER_STATUS,
-    statusCode: statusCode,
-    message: message
+    type: SET_STATUS_CODE,
+    statusCode: statusCode
   };
 }

--- a/src/lib/reducers.js
+++ b/src/lib/reducers.js
@@ -1,4 +1,4 @@
-import { RENDER_STATUS } from "./actions";
+import { SET_STATUS_CODE } from "./actions";
 
 const INITIAL_STATE={};
 
@@ -9,13 +9,10 @@ const INITIAL_STATE={};
  */
 export default function _gluestick(state=INITIAL_STATE, action) {
   switch(action.type) {
-    case RENDER_STATUS: {
+    case SET_STATUS_CODE: {
       return {
         ...state,
-        error: {
-          message: action.message,
-          status: action.statusCode
-        }
+        statusCode: action.statusCode
       };
     }
     default:


### PR DESCRIPTION
The previous action creator names for setting the server status codes
were sort of misleading with the name `render` in them. It made a user
think that some sort of page render was going on, when really we are
just setting the status code of the response on the server.

~~Also, we do still want a way to render generic error pages (status code and page with a message). Add an action creator for dispatching actions that ask GlueStick to do just that.~~ (to be included in a future PR)