### PR TITLE
Ensure all cookies from the cookie jar are set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick-shared",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {

--- a/src/lib/getHttpClient.js
+++ b/src/lib/getHttpClient.js
@@ -50,7 +50,10 @@ export default function getHttpClient (options={}, req, res, httpClient=axios) {
       // undesired effects. Currently, the suggested solution for dealing with
       // this problem is to make the API requests to A or B in the browser and
       // not in gsBeforeRoute for apps where that is an issue.
-      res.header("Set-Cookie", cookieString);
+      res.removeHeader("Set-Cookie");
+      cookiejar.forEach(cookie => {
+        res.append("Set-Cookie", cookie);
+      });
 
       // Ensure that any subsequent requests are passing the cookies.
       // This is for instances where there is no browser persisting the cookies.

--- a/test/lib/getHttpClient.test.js
+++ b/test/lib/getHttpClient.test.js
@@ -108,7 +108,8 @@ describe("lib/getHttpClient", () => {
     };
 
     const mockServerResponse = {
-      header: sinon.spy()
+      removeHeader: sinon.spy(),
+      append: sinon.spy()
     };
 
     const client = getHttpClient({}, req, mockServerResponse, axiosMock);
@@ -118,8 +119,7 @@ describe("lib/getHttpClient", () => {
       }
     });
 
-    expect(mockServerResponse.header.lastCall.args[0]).to.equal("Set-Cookie");
-    expect(mockServerResponse.header.lastCall.args[1]).to.equal("oh hai");
+    expect(mockServerResponse.append.lastCall.args).to.deep.equal(["Set-Cookie", "oh hai"]);
   });
 
   it("should set default cookies on the axios instance", () => {
@@ -132,7 +132,8 @@ describe("lib/getHttpClient", () => {
     };
 
     const mockServerResponse = {
-      header: sinon.spy()
+      removeHeader: sinon.spy(),
+      append: sinon.spy()
     };
 
     const client = getHttpClient({}, req, mockServerResponse, axiosMock);


### PR DESCRIPTION
Previously, only the first cookie in the cookie string was being sent to the browser. We want to set all cookies by iterating through each and appending to the response header.