### PR TITLE
Fix react-router-scroll import

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": ">=0.14.3",
     "react-redux": ">=4.0.1",
     "react-router": ">=2.0.0",
-    "react-router-scroll": ">=0.2.0",
+    "react-router-scroll": ">=0.3.0",
     "react-side-effect": "1.0.2",
     "redux": ">=3.3.1",
     "redux-immutable-state-invariant": "1.2.2",

--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { applyRouterMiddleware, Router, browserHistory } from "react-router";
 import { Provider } from "react-redux";
-import useScroll from "react-router-scroll";
+import { useScroll } from "react-router-scroll";
 
 import prepareRoutesWithTransitionHooks from "../lib/prepareRoutesWithTransitionHooks";
 


### PR DESCRIPTION
The upgrade to 3.0 introduced a breaking change with respect to how useScroll is imported.

Fixes https://github.com/TrueCar/gluestick/issues/231