### PR TITLE
support disabling scroll on route change

### DIFF
--- a/src/containers/Root.js
+++ b/src/containers/Root.js
@@ -52,8 +52,21 @@ export default class Root extends Component {
     // server rendering
     if (routerContext) return routerContext;
 
+    // router middleware
+    const render = applyRouterMiddleware(
+      useScroll((prevRouterProps, { routes }) => {
+        // Do not scroll on route change if a `ignoreScrollBehavior` prop is set to true on
+        // route components in the app. e.g.
+        // <Route ignoreScrollBehavior={true} path="mypage" component={MyComponent} />
+        if (routes.some(route => route.ignoreScrollBehavior)) {
+          return false;
+        }
+        return true;
+      })
+    );
+
     return (
-      <Router history={routerHistory} render={applyRouterMiddleware(useScroll())}>
+      <Router history={routerHistory} render={render}>
         {prepareRoutesWithTransitionHooks(routes)}
       </Router>
     );


### PR DESCRIPTION
```
This change gives users an option to disable react-router-scroll's
default behavior by setting a `ignoreScrollBehavior` prop to `true` on
the route component. e.g.

    <Route ignoreScrollBehavior={true} path="mypage" component={MyComponent} />

If `ignoreScrollBehavior` is omitted or set to `false`, the default
react-router-scroll behavior is used.

Code was copied from react-router-scroll's README here:
https://github.com/taion/react-router-scroll#custom-scroll-behavior
```

Let me know if this sounds reasonable. Not sure if you want to use a different name than `ignoreScrollBehavior`. No rush on reviewing this.