### PR TITLE
Improve cookie name value parsing

### DIFF
--- a/src/lib/cookies.js
+++ b/src/lib/cookies.js
@@ -44,7 +44,7 @@ export function parse(cookieString) {
   let c = new Cookie();
 
   cookieString.split(";").forEach(s => {
-    const m = new RegExp("([a-zA-Z\-\_]+)=([a-zA-Z0-9\%\-\_\=\/\.\,\:\\s]+)", "g").exec(s.trim());
+    const m = new RegExp("([\\w\%\-]+)=(.+)", "g").exec(s.trim());
     let k = s.trim(), v;
 
     if (m !== null) {

--- a/test/lib/cookies.test.js
+++ b/test/lib/cookies.test.js
@@ -10,6 +10,13 @@ describe("lib/cookies", () => {
       expect(cookieJar[0].value).to.equal("barbaz==");
     });
 
+    it("parses a cookie's name containing alpha-numeric characters from a string", () => {
+      const cookieJar = parse("foo0123foo=barbaz==");
+      expect(cookieJar.length).to.equal(1);
+      expect(cookieJar[0].name).to.equal("foo0123foo");
+      expect(cookieJar[0].value).to.equal("barbaz==");
+    });
+
     it("parses a cookie's path from a string", () => {
       const cookieJar = parse("foo=barbaz==; path=/");
       expect(cookieJar.length).to.equal(1);


### PR DESCRIPTION
Previously, cookies containing numeric characters in the name were not being parsed properly. This fixes that and also cleans up the regex as a whole.