### PR TITLE
Stop using axios defaults for cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick-shared",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {

--- a/src/lib/cookies.js
+++ b/src/lib/cookies.js
@@ -15,9 +15,17 @@ function Cookie(name=null, value=null, options={}) {
   this.options = options;
 }
 
-Cookie.prototype.toString = function() {
+Cookie.prototype.toString = function(incoming=true) {
+  if (!this.name) {
+    return "";
+  }
+
   const kvs = [`${this.name}=${encodeURIComponent(this.value)}`];
   const bvs = [];
+
+  if (!incoming) {
+    return kvs[0];
+  }
 
   Object.keys(COOKIE_OPTS).forEach(attr => {
     const value = this.options[attr];

--- a/test/lib/cookies.test.js
+++ b/test/lib/cookies.test.js
@@ -102,4 +102,23 @@ describe("lib/cookies", () => {
       expect(merge(oldCookies, "")).to.equal("foo=baz%3D%3D");
     });
   });
+
+  describe("Cookie => toString", () => {
+    it("should return a cookie string with option attributes when incoming", () => {
+      const cookies = parse("some-thing-a=true; path=/; foo=hi; path=/ HttpOnly");
+      expect(`${cookies[0]}`).to.equal("some-thing-a=true; path=/");
+      expect(`${cookies[1]}`).to.equal("foo=hi; path=/ HttpOnly");
+    });
+
+    it("should return a cookie string without option attributes when outgoing", () => {
+      const cookies = parse("some-thing-a=true; path=/; foo=hi; path=/ HttpOnly");
+      expect(cookies[0].toString(false)).to.equal("some-thing-a=true");
+      expect(cookies[1].toString(false)).to.equal("foo=hi");
+    });
+
+    it("returns an empty string if cookie value doesn't have name", () => {
+      const cookies = parse("");
+      expect(cookies[0].toString()).to.equal("");
+    }); 
+  });
 });


### PR DESCRIPTION
Axios was recycling the defaults object even in new axios instances so
it can not be trusted (for now).

We also had a fundamental issue with how we were treating incoming and
outgoing cookies. Cookeis that are part of a request object do not
include path, when we were sending the cookies with path, it was parsing
out the path as a separate cookie and mutating the desired cookies. Now
we treat incoming and outgoing cookies separately.