### PR TITLE
don't swallow exceptions in promiseMiddleware

### DIFF
--- a/src/lib/promiseMiddleware.js
+++ b/src/lib/promiseMiddleware.js
@@ -25,14 +25,16 @@ export default function promiseMiddleware (client) {
       }
 
       return getPromise(client)
-        .then(value => {
-          next({...rest, value, type: SUCCESS});
-          return value || true;
-        })
-        .catch(error => {
-          next({...rest, error, type: FAILURE});
-          return false;
-        });
+        .then(
+          value => {
+            next({...rest, value, type: SUCCESS});
+            return value || true;
+          },
+          error => {
+            next({...rest, error, type: FAILURE});
+            return false;
+          }
+        );
     };
   };
 }


### PR DESCRIPTION
use second argument of `.then` to catch promise failures instead of
`.catch`. addresses https://github.com/TrueCar/gluestick/issues/354