### PR TITLE
don't discard headers when making requests from server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gluestick-shared",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "description": "This contains the shared code in the GlueStick CLI and the apps that it generates.",
   "main": "./build/index.js",
   "scripts": {

--- a/src/lib/getHttpClient.js
+++ b/src/lib/getHttpClient.js
@@ -52,7 +52,7 @@ export default function getHttpClient (options={}, req, res, httpClient=axios) {
     const output = {
       ...config,
       headers: {
-        ...headers,
+        ...config.headers,
         cookie: merge(outgoingCookies, merge(config.headers.cookie, newCookies))
       }
     };


### PR DESCRIPTION
previously headers from various sources (server request object, config
passed to `get` call, and config set in an axios intercepter in
`modifyInstance`) were discarded when making requests from the server.

add new tests using a new method of mocking axios.

I wanted to use https://github.com/mzabriskie/moxios for mocking axios but I did not get it to work with axios 0.12.0.
Example working with axios 0.15.3: https://github.com/saltycrane/moxios-example/tree/master
Example not working with axios 0.12.0: https://github.com/saltycrane/moxios-example/tree/axios-0.12.0